### PR TITLE
Remove Package Metadata

### DIFF
--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,5 +1,0 @@
-{
-    "description": "Sublime Text 3 syntax highlighting and code completion package for Luo",
-    "version": "2014.07.16.18.48.50",
-    "url": "https://github.com/GravityScore/ST2-ComputerCraft-Package"
-}


### PR DESCRIPTION
The `package-metadata.json` file is automagically generated by [Package Control](https://packagecontrol.io) and used internally. Plus, the current one contains invalid `url` and `version` fields.
